### PR TITLE
Add a reference to latest remotipart document.

### DIFF
--- a/_posts/2012-01-09-remotipart.md
+++ b/_posts/2012-01-09-remotipart.md
@@ -33,6 +33,7 @@ articles:
     href: http://www.alfajango.com/blog/rails-3-ajax-file-uploads-with-remotipart/
 ---
 
+The content on this page is out of date. Please refer latest document on GitHub repos.
 
 For an introduction explaining how and why Remotipart works, check out [AJAX File Uploads with the iFrame Method](http://www.alfajango.com/blog/ajax-file-uploads-with-the-iframe-method/) and [Rails 3 AJAX File Uploads with Remotipart](http://www.alfajango.com/blog/rails-3-ajax-file-uploads-with-remotipart/).
 

--- a/_posts/2012-01-09-remotipart.md
+++ b/_posts/2012-01-09-remotipart.md
@@ -33,7 +33,7 @@ articles:
     href: http://www.alfajango.com/blog/rails-3-ajax-file-uploads-with-remotipart/
 ---
 
-The content on this page is out of date. Please refer latest document on GitHub repos.
+The content on this page is out of date. Please refer [latest document](https://github.com/JangoSteve/remotipart) on GitHub repos.
 
 For an introduction explaining how and why Remotipart works, check out [AJAX File Uploads with the iFrame Method](http://www.alfajango.com/blog/ajax-file-uploads-with-the-iframe-method/) and [Rails 3 AJAX File Uploads with Remotipart](http://www.alfajango.com/blog/rails-3-ajax-file-uploads-with-remotipart/).
 


### PR DESCRIPTION
Thank you for your contribution to remotipart gem.

I have a request for you to update documentation for remotipart on [this site](https://os.alfajango.com/remotipart/).

My suggestion is below:

- adding a reference or a link to [remotipart/README.rdoc at master · JangoSteve/remotipart](https://github.com/JangoSteve/remotipart/blob/master/README.rdoc)  on this site.

Because: 
- It seems the documentation for remotipart on [this site](https://os.alfajango.com/remotipart/) is out of date in comparison with [remotipart/README.rdoc at master · JangoSteve/remotipart](https://github.com/JangoSteve/remotipart/blob/master/README.rdoc)
  - e.g. There is no reference about compatibility for Rails 4.
- I want to use your great gem on Rails 5, and also want to add reference about compatibility for Rails 5 to documentation for remotipart. But I'm little confusing because there are two documentations and there are differences between them.

Note:
I couldn't check my update is valid, because I don't know how to build this site. I with you could tell me how to build.

Thank you for your consideration.